### PR TITLE
Specify image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   shogun-postgis:
-    image: postgis/postgis:13-master
+    image: postgis/postgis:13-3.1-alpine
     ports:
       - 5555:5432
     environment:
@@ -11,7 +11,7 @@ services:
       - ./shogun-postgis/postgresql_data:/var/lib/postgresql/data:Z
       - ./shogun-postgis/init_data/01_init_keycloak.sql:/docker-entrypoint-initdb.d/01_init_keycloak.sql
   shogun-redis:
-    image: library/redis:6-alpine
+    image: redis:6.2.1-alpine
     ports:
       - 6379:6379
     environment:
@@ -29,7 +29,7 @@ services:
       - ./shogun-redis/redis_data:/data
       - ./shogun-redis/redis_config:/config
   shogun-keycloak:
-    image: jboss/keycloak:11.0.2
+    image: jboss/keycloak:12.0.4
     ports:
       - 8000:8080
     environment:


### PR DESCRIPTION
Specifies the image versions for postgis and redis and also updates the keycloak image.

Resolves #7.

Please review @terrestris/devs.