### PR TITLE
Update keycloak image to v14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./shogun-redis/redis_data:/data
       - ./shogun-redis/redis_config:/config
   shogun-keycloak:
-    image: jboss/keycloak:12.0.4
+    image: jboss/keycloak:14.0.0
     ports:
       - 8000:8080
     environment:


### PR DESCRIPTION
This updates the keycloak image to the latestest releae (version 14).

See [#340](https://github.com/terrestris/shogun/pull/340) (shogun) as well.

Please note @terrestris/devs.