### PR TITLE
adjust volume mounts for java 17 update

### DIFF
--- a/docker-compose-shogun.yml
+++ b/docker-compose-shogun.yml
@@ -19,7 +19,7 @@ services:
       KEYCLOAK_DISABLE_TRUST_MANAGER: ${KEYCLOAK_DISABLE_TRUST_MANAGER}
     volumes:
       - ./shogun-boot/application.yml:/config/application.yml
-      - ./shogun-boot/keystore/cacerts:/usr/local/openjdk-11/lib/security/cacerts
+      - ./shogun-boot/keystore/cacerts:/usr/local/openjdk-17/lib/security/cacerts
     depends_on:
       - shogun-postgis
       - shogun-redis
@@ -43,7 +43,7 @@ services:
       KEYCLOAK_DISABLE_TRUST_MANAGER: ${KEYCLOAK_DISABLE_TRUST_MANAGER}
     volumes:
       - ./shogun-boot/application.yml:/config/application.yml
-      - ./shogun-boot/keystore/cacerts:/usr/local/openjdk-11/lib/security/cacerts
+      - ./shogun-boot/keystore/cacerts:/usr/local/openjdk-17/lib/security/cacerts
     depends_on:
       - shogun-postgis
       - shogun-redis
@@ -86,7 +86,7 @@ services:
       KEYCLOAK_DISABLE_TRUST_MANAGER: ${KEYCLOAK_DISABLE_TRUST_MANAGER}
     volumes:
       - ./shogun-gs-interceptor/application.yml:/config/application.yml
-      - ./shogun-boot/keystore/cacerts:/usr/local/openjdk-11/lib/security/cacerts
+      - ./shogun-boot/keystore/cacerts:/usr/local/openjdk-17/lib/security/cacerts
     depends_on:
       - shogun-postgis
       - shogun-redis


### PR DESCRIPTION
Updates volume mount in docker-compose config for jdk 17.

@terrestris/devs Please review

:exclamation: you need to make sure you're using shogun images with jdk 17, see https://github.com/terrestris/shogun/pull/385 / https://github.com/terrestris/shogun/pull/385/checks?check_run_id=3789136806