### PR TITLE
fix: add optional config volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ docker-compose -f docker-compose.yml -f docker-compose-dev.yml up
 You can test whether the Keycloak application started by visiting the URL
 `https://localhost/auth/`.
 
+If you want to use a custom `application.yml` you can achieve this by enabling the volume mount for `shogun-boot` here: [docker-compose-dev.yml](docker-compose-dev.yml#L37).
+
+You also need to modify https://github.com/terrestris/shogun/blob/main/shogun-boot/Dockerfile#L29
+
 ### Import the initial Keycloak data
 
 See section [Keycloak Import](#import).

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,7 +34,8 @@ services:
       - ../shogun/:/shogun/
       - ~/.m2:/root/.m2
       - ./shogun-boot/keystore/cacerts:/etc/pki/ca-trust/extracted/java/cacerts
-      - ./shogun-boot/application.yml:/config/application.yml
+    # enable this line when using a custom application.yml
+    #  - ./shogun-boot/application.yml:/config/application.yml
     depends_on:
       - shogun-postgis
       - shogun-redis

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -34,6 +34,7 @@ services:
       - ../shogun/:/shogun/
       - ~/.m2:/root/.m2
       - ./shogun-boot/keystore/cacerts:/etc/pki/ca-trust/extracted/java/cacerts
+      - ./shogun-boot/application.yml:/config/application.yml
     depends_on:
       - shogun-postgis
       - shogun-redis


### PR DESCRIPTION
Fixes shogun startup when running `docker-compose -f docker-compose.yml -f docker-compose-dev.yml up`.

Adds info to readme on how to override application.yml.

@terrestris/devs Please review