### PR TITLE
Update keycloak container to version 15.0.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - ./shogun-redis/redis_data:/data
       - ./shogun-redis/redis_config:/config
   shogun-keycloak:
-    image: jboss/keycloak:14.0.0
+    image: jboss/keycloak:15.0.2
     ports:
       - "8000:8080"
     environment:


### PR DESCRIPTION
This updates the keycloak container to version `15.0.2`. 

An update from the older version was tested successfully.

Please review @terrestris/devs.