### PR TITLE
Update all third-party images

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   shogun-nginx:
-    image: nginx:1.21.1
+    image: nginx:1.21.6
     volumes:
       - ./shogun-nginx/default-dev.conf:/etc/nginx/conf.d/default.conf
       - ./shogun-nginx/ssl/private/localhost.crt:/etc/nginx/ssl/private/localhost.crt

--- a/docker-compose-shogun.yml
+++ b/docker-compose-shogun.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   shogun-nginx:
-    image: nginx:1.21.1
+    image: nginx:1.21.6
     volumes:
       - ./shogun-nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./shogun-nginx/ssl/private/localhost.crt:/etc/nginx/ssl/private/localhost.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ./shogun-geoserver/geoserver_data:/opt/geoserver_data/:Z
       - ./shogun-geoserver/additional_libs:/opt/additional_libs/:Z
   shogun-postgis:
-    image: postgis/postgis:13-3.1-alpine
+    image: postgis/postgis:13-3.2-alpine
     ports:
       - "5555:5432"
     environment:
@@ -25,7 +25,7 @@ services:
       - ./shogun-postgis/postgresql_data:/var/lib/postgresql/data:Z
       - ./shogun-postgis/init_data/01_init_keycloak.sql:/docker-entrypoint-initdb.d/01_init_keycloak.sql
   shogun-redis:
-    image: redis:6.2.1-alpine
+    image: redis:6.2.6-alpine
     ports:
       - "6379:6379"
     environment:
@@ -43,7 +43,7 @@ services:
       - ./shogun-redis/redis_data:/data
       - ./shogun-redis/redis_config:/config
   shogun-keycloak:
-    image: jboss/keycloak:15.0.2
+    image: jboss/keycloak:16.1.1
     ports:
       - "8000:8080"
     environment:

--- a/shogun-geoserver/Dockerfile
+++ b/shogun-geoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM terrestris/geoserver:2.19.2
+FROM terrestris/geoserver:2.20.2
 
 ARG USER_UID
 ARG USER_GID


### PR DESCRIPTION
This updates all third-party docker images:

* nginx: `1.21.1` -> `1.21.6`
* postgis/postgis: `13-3.1-alpine` -> `13-3.2-alpine`
* redis: `6.2.1-alpine` -> `6.2.6-alpine`
* jboss/keycloak: `15.0.2` -> `16.1.1`
* terrestris/geoserver: `2.19.2` -> `2.20.2`

Please review @terrestris/devs.