### PR TITLE
Add shogun-admin to docker-compose files

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -40,3 +40,7 @@ services:
       - shogun-postgis
       - shogun-redis
       - shogun-keycloak
+  shogun-admin:
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:5.1.0
+    ports:
+      - 8005:80

--- a/docker-compose-shogun.yml
+++ b/docker-compose-shogun.yml
@@ -60,3 +60,7 @@ services:
       - shogun-postgis
       - shogun-redis
       - shogun-keycloak
+  shogun-admin:
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:5.1.0
+    ports:
+      - 8005:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,3 +58,7 @@ services:
       PROXY_ADDRESS_FORWARDING: "true"
     depends_on:
       - shogun-postgis
+  shogun-admin:
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:5.1.0
+    ports:
+      - 8005:80


### PR DESCRIPTION
This adds the `shogun-admin` to all compose files.
This should have been done before i changed the [README](https://github.com/terrestris/shogun-admin#docker) of the shogun-admin :grin: 