### PR TITLE
Update shogun-admin version, add nginx forwarding

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -46,7 +46,3 @@ services:
       dockerfile: Dockerfile.dev
     volumes:
       - ../shogun-demo-client:/app
-  shogun-admin:
-    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:5.1.0
-    ports:
-      - 8005:80

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -46,3 +46,7 @@ services:
       dockerfile: Dockerfile.dev
     volumes:
       - ../shogun-demo-client:/app
+  shogun-admin:
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:7.2.0
+    ports:
+      - 8005:80

--- a/docker-compose-shogun.yml
+++ b/docker-compose-shogun.yml
@@ -61,6 +61,6 @@ services:
       - shogun-redis
       - shogun-keycloak
   shogun-admin:
-    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:5.1.0
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:latest
     ports:
       - 8005:80

--- a/docker-compose-shogun.yml
+++ b/docker-compose-shogun.yml
@@ -60,7 +60,3 @@ services:
       - shogun-postgis
       - shogun-redis
       - shogun-keycloak
-  shogun-admin:
-    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:latest
-    ports:
-      - 8005:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,6 @@ services:
     depends_on:
       - shogun-postgis
   shogun-admin:
-    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:latest
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:7.2.0
     ports:
       - 8005:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,6 @@ services:
     depends_on:
       - shogun-postgis
   shogun-admin:
-    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:5.1.0
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:latest
     ports:
       - 8005:80

--- a/shogun-nginx/default-dev.conf
+++ b/shogun-nginx/default-dev.conf
@@ -50,6 +50,24 @@ server {
     proxy_read_timeout 600;
   }
 
+  location /admin/ {
+    proxy_pass http://shogun-admin:80/;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
+    proxy_read_timeout 600;
+
+    add_header 'Access-Control-Allow-Origin' '*' always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+  }
+
   location /geoserver/ {
     proxy_pass http://shogun-geoserver:8080/geoserver/;
 

--- a/shogun-nginx/default-dev.conf
+++ b/shogun-nginx/default-dev.conf
@@ -54,18 +54,6 @@ server {
     proxy_pass http://shogun-admin:80/;
 
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Host $host;
-    proxy_set_header X-Forwarded-Port $server_port;
-
-    proxy_read_timeout 600;
-
-    add_header 'Access-Control-Allow-Origin' '*' always;
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
-    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
   }
 
   location /geoserver/ {

--- a/shogun-nginx/default.conf
+++ b/shogun-nginx/default.conf
@@ -50,6 +50,24 @@ server {
     proxy_set_header X-Forwarded-Port $server_port;
   }
 
+  location /admin/ {
+    proxy_pass http://shogun-admin:80/;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
+    proxy_read_timeout 600;
+
+    add_header 'Access-Control-Allow-Origin' '*' always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
+    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+  }
+
   location /geoserver/ {
     proxy_pass http://shogun-geoserver:8080/geoserver/;
 


### PR DESCRIPTION
- This changes the shogun-admin version to the latest.  
- Adds respective nginx entries for shogun-admin.

- Correct headers within nginx location entry?
- I added the **shogun-admin** to `docker-compose` and `docker-compose-shogun`. Unsure, if it would be better to add it within `docker-compose-dev`?

@terrestris/devs please check.


