### PR TITLE
Adds pathes and container-prefix as environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,11 @@
+# SHOGun pathes
+SHOGUN_DIR=../shogun
+SHOGUN_ADMIN_DIR=../shogun-admin
+SHOGUN_CLIENT_DIR=../shogun-demo-client
+
+# Container prefix
+CONTAINER_NAME_PREFIX=shogun
+
 # The mail server host
 MAIL_HOST=mail.terrestris.de
 # The mail server port

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   shogun-nginx:
+    container_name: ${CONTAINER_NAME_PREFIX}-nginx
     image: nginx:1.21.6
     volumes:
       - ./shogun-nginx/dev/default.conf:/etc/nginx/conf.d/default.conf
@@ -15,25 +16,28 @@ services:
       - shogun-geoserver
       - shogun-demo-client
       - shogun-admin
-  shogun-demo-client:
+  shogun-client:
+    container_name: ${CONTAINER_NAME_PREFIX}-demo-client
     build:
-      context: ../shogun-demo-client
+      context: ${SHOGUN_CLIENT_DIR}
       dockerfile: Dockerfile.dev
     ports:
       - 3000:3000
     volumes:
-      - ../shogun-demo-client:/app
+      - ${SHOGUN_CLIENT_DIR}:/app
   shogun-admin:
+    container_name: ${CONTAINER_NAME_PREFIX}-admin
     build:
-      context: ../shogun-admin
+      context: ${SHOGUN_ADMIN_DIR}
       dockerfile: Dockerfile.dev
     ports:
       - 9090:9090
     volumes:
-      - ../shogun-admin:/app
+      - ${SHOGUN_ADMIN_DIR}:/app
   shogun-boot:
+    container_name: ${CONTAINER_NAME_PREFIX}-boot
     build:
-      context: ../shogun/shogun-boot/
+      context: ${SHOGUN_DIR}/shogun-boot/
     ports:
       - "8080:8080"
       - "4711:4711"
@@ -49,13 +53,32 @@ services:
       KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}
       KEYCLOAK_DISABLE_TRUST_MANAGER: ${KEYCLOAK_DISABLE_TRUST_MANAGER}
     volumes:
-      - ../shogun/:/shogun/
+      - ${SHOGUN_DIR}/:/shogun/
       - ~/.m2:/root/.m2
       - ./shogun-boot/keystore/cacerts:/etc/pki/ca-trust/extracted/java/cacerts
       - ./shogun-boot/admin/config/admin-client-config.js:/shogun/shogun-boot/src/main/resources/templates/admin-client-config.js
       - ./shogun-boot/admin/modelconfigs/:/shogun/shogun-boot/src/main/resources/static/modelconfigs/
     # enable this line when using a custom application.yml
     #  - ./shogun-boot/application.yml:/config/application.yml
+    depends_on:
+      - shogun-postgis
+      - shogun-redis
+      - shogun-keycloak
+  shogun-gs-interceptor:
+    container_name: ${CONTAINER_NAME_PREFIX}-gs-interceptor
+    image: nexus.terrestris.de/shogun/shogun-gs-interceptor:latest
+    ports:
+      - "8083:8081"
+    environment:
+      DB_USER: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      KEYCLOAK_HOST: ${KEYCLOAK_HOST}
+      KEYCLOAK_USER: ${KEYCLOAK_USER}
+      KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}
+      KEYCLOAK_DISABLE_TRUST_MANAGER: ${KEYCLOAK_DISABLE_TRUST_MANAGER}
+    volumes:
+      - ./shogun-gs-interceptor/application.yml:/config/application.yml
+      - ./shogun-boot/keystore/cacerts:/etc/pki/ca-trust/extracted/java/cacerts
     depends_on:
       - shogun-postgis
       - shogun-redis

--- a/docker-compose-shogun.yml
+++ b/docker-compose-shogun.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   shogun-nginx:
+    container_name: ${CONTAINER_NAME_PREFIX}-nginx
     image: nginx:1.21.6
     volumes:
       - ./shogun-nginx/test/default.conf:/etc/nginx/conf.d/default.conf
@@ -14,17 +15,15 @@ services:
       - shogun-boot
       - shogun-gs-interceptor
       - shogun-admin
-      # - shogun-demo-client
+      - shogun-demo-client
   shogun-admin:
+    container_name: ${CONTAINER_NAME_PREFIX}-admin
     image: nexus.terrestris.de/repository/terrestris-public/shogun-admin:7.5.2
-    ports:
-      - 8005:80
-  # TODO Image does not exist yet
-  # shogun-demo-client:
-  #   image: nexus.terrestris.de/repository/terrestris-public/shogun-demo-client:latest
-  #   ports:
-  #     - 8005:80
+  shogun-client:
+    container_name: ${CONTAINER_NAME_PREFIX}-client
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-demo-client:3.1.1
   shogun-boot:
+    container_name: ${CONTAINER_NAME_PREFIX}-boot
     image: nexus.terrestris.de/shogun/shogun-boot:latest
     deploy:
       mode: replicated
@@ -33,9 +32,6 @@ services:
         limits:
           cpus: '0.50'
           memory: 1G
-    ports:
-      - "8080-8082:8080"
-      - "5005-5007:5005"
     environment:
       JAVA_TOOL_OPTIONS: "-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Xmx512m -Djdk.serialSetFilterAfterRead=true -Dspring.config.location=/config/application.yml"
       MAIL_HOST: ${MAIL_HOST}
@@ -57,9 +53,8 @@ services:
       - shogun-redis
       - shogun-keycloak
   shogun-gs-interceptor:
+    container_name: ${CONTAINER_NAME_PREFIX}-gs-interceptor
     image: nexus.terrestris.de/shogun/shogun-gs-interceptor:latest
-    ports:
-      - "8083:8081"
     environment:
       DB_USER: ${POSTGRES_USER}
       DB_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 services:
   shogun-geoserver:
+    container_name: shogun-geoserver
     build:
       context: ./shogun-geoserver
       args:
@@ -16,6 +17,7 @@ services:
       - ./shogun-geoserver/geoserver_data:/opt/geoserver_data/:Z
       - ./shogun-geoserver/additional_libs:/opt/additional_libs/:Z
   shogun-postgis:
+    container_name: shogun-postgis
     image: postgis/postgis:13-3.2-alpine
     ports:
       - "5555:5432"
@@ -26,6 +28,7 @@ services:
       - ./shogun-postgis/postgresql_data:/var/lib/postgresql/data:Z
       - ./shogun-postgis/init_data/01_init_keycloak.sql:/docker-entrypoint-initdb.d/01_init_keycloak.sql
   shogun-redis:
+    container_name: shogun-redis
     image: redis:6.2.6-alpine
     ports:
       - "6379:6379"
@@ -44,6 +47,7 @@ services:
       - ./shogun-redis/redis_data:/data
       - ./shogun-redis/redis_config:/config
   shogun-keycloak:
+    container_name: shogun-keycloak
     image: jboss/keycloak:16.1.1
     ports:
       - "8000:8080"

--- a/shogun-nginx/dev/default.conf
+++ b/shogun-nginx/dev/default.conf
@@ -87,7 +87,7 @@ server {
   }
 
   location /client/ {
-    proxy_pass https://shogun-demo-client:3000/;
+    proxy_pass https://shogun-client:3000/;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This adds the following environemnt variables which get used by the docker-compose files:
```yml
# SHOGun pathes
SHOGUN_DIR=../shogun
SHOGUN_ADMIN_DIR=../shogun-admin
SHOGUN_CLIENT_DIR=../shogun-demo-client

# Container prefix
CONTAINER_NAME_PREFIX=shogun
```

It also adds the missing `shogun-gs-interceptor` to the `docker-compose-dev.yml` and the `shogun-demo-client` image to `docker-compose-shogun.yml`.