### PR TITLE
Disable auth check for client and admin

### DIFF
--- a/shogun-nginx/dev/default.conf
+++ b/shogun-nginx/dev/default.conf
@@ -91,10 +91,6 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
-
-    auth_request .auth;
-    error_page 401 = @error401;
-    error_page 403 = @error403;
   }
 
   location /client/ {
@@ -126,20 +122,5 @@ server {
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
     add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
     add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-  }
-
-  location @error401 {
-    add_header Set-Cookie "KC_REDIRECT=$request_uri; Domain=$host; Path=/; HttpOnly; Secure";
-    return 302 /sso/login;
-  }
-
-  location @error403 {
-    add_header Set-Cookie "KC_REDIRECT=$request_uri; Domain=$host; Path=/; HttpOnly; Secure";
-    return 302 /;
-  }
-
-  location .auth {
-    internal;
-    proxy_pass http://shogun-boot:8080/auth/isSessionValid;
   }
 }

--- a/shogun-nginx/prod/default.conf
+++ b/shogun-nginx/prod/default.conf
@@ -95,19 +95,19 @@ server {
     proxy_set_header X-Forwarded-Port $server_port;
   }
 
-  # location /client/ {
-  #   proxy_pass http://shogun-demo-client/;
+  location /client/ {
+    proxy_pass http://shogun-demo-client/;
 
-  #   proxy_http_version 1.1;
-  #   proxy_set_header Upgrade $http_upgrade;
-  #   proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
 
-  #   proxy_set_header Host $host;
-  #   proxy_set_header X-Real-IP $remote_addr;
-  #   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  #   proxy_set_header X-Forwarded-Proto $scheme;
-  #   proxy_set_header X-Forwarded-Port $server_port;
-  # }
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+  }
 
   location / {
     proxy_pass http://shogun-boot;

--- a/shogun-nginx/prod/default.conf
+++ b/shogun-nginx/prod/default.conf
@@ -93,10 +93,6 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
-
-    auth_request .auth;
-    error_page 401 = @error401;
-    error_page 403 = @error403;
   }
 
   # location /client/ {
@@ -128,18 +124,4 @@ server {
     add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
   }
 
-  location @error401 {
-    add_header Set-Cookie "KC_REDIRECT=$request_uri; Domain=$host; Path=/; HttpOnly; Secure";
-    return 302 /sso/login;
-  }
-
-  location @error403 {
-    add_header Set-Cookie "KC_REDIRECT=$request_uri; Domain=$host; Path=/; HttpOnly; Secure";
-    return 302 /;
-  }
-
-  location .auth {
-    internal;
-    proxy_pass http://shogun-boot/auth/isSessionValid;
-  }
 }


### PR DESCRIPTION
With [PR126](https://github.com/terrestris/shogun-demo-client/pull/126) and [PR95](https://github.com/terrestris/shogun-admin/pull/95) the auth module is no longer needed as the clients do redirect to Keycloak by themselves.

Please review @terrestris/devs.