### PR TITLE
Add some inline docs

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -89,7 +89,7 @@ services:
           cpus: '0.50'
           memory: 1G
     environment:
-      JAVA_TOOL_OPTIONS: "-Xmx512m -Dspring.config.location=/config/application.yml -Dlog4j2.configurationFile=file:/config/log4j2.yml"
+      JAVA_TOOL_OPTIONS: "-Xmx512m -Dspring.config.location=/config/application.yml -Dlog4j2.configurationFile=/config/log4j2.yml"
     restart: unless-stopped
     healthcheck:
       test: curl --fail "http://localhost:8080" || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
     ports:
       - "4711:4711"
       - "9010:9010"
+    # Enable if you want to make use of the external application and log configurations
+    # environment:
+    #   JAVA_TOOL_OPTIONS: "-Dspring.config.location=/config/application.yml -Dlog4j2.configurationFile=/config/log4j2.yml"
     volumes:
       - ${SHOGUN_DIR}/:/shogun/
       - ~/.m2:/root/.m2

--- a/shogun-boot/application.yml
+++ b/shogun-boot/application.yml
@@ -1,3 +1,7 @@
+# Please note: This file is not used in the development environment/mode by default!
+#              To make use of it, enable the "-Dspring.config.location=/config/application.yml"
+#              config option via the JAVA_TOOL_OPTIONS environment variable in the compose file.
+
 server:
   port: 8080
   # this flag is needed to properly redirect to https:

--- a/shogun-boot/log4j2.yml
+++ b/shogun-boot/log4j2.yml
@@ -1,3 +1,7 @@
+# Please note: This file is not used in the development environment/mode by default!
+#              To make use of it, enable the "Dlog4j2.configurationFile=/config/log4j2.yml"
+#              config option via the JAVA_TOOL_OPTIONS environment variable in the compose file.
+
 Configuration:
   Appenders:
     Console:


### PR DESCRIPTION
Clarify instructions on how to enable the external configurations in development mode. This can be useful to test logging configurations or similar.

Please review @terrestris/devs.