### PR TITLE
Update client and admin proxy paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
     build:
       context: ${SHOGUN_CLIENT_DIR}
       dockerfile: Dockerfile.dev
-    ports:
-      - "3000:3000"
     volumes:
       - ${SHOGUN_CLIENT_DIR}:/app
   shogun-admin:
@@ -48,8 +46,6 @@ services:
     build:
       context: ${SHOGUN_ADMIN_DIR}
       dockerfile: Dockerfile.dev
-    ports:
-      - "9090:9090"
     volumes:
       - ${SHOGUN_ADMIN_DIR}:/app
   shogun-boot:

--- a/shogun-nginx/dev/default.conf
+++ b/shogun-nginx/dev/default.conf
@@ -67,7 +67,7 @@ server {
   }
 
   location /admin/ {
-    proxy_pass https://shogun-admin:9090/;
+    proxy_pass http://shogun-admin:8080/;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -93,7 +93,7 @@ server {
   }
 
   location /client/ {
-    proxy_pass https://shogun-client:3000/;
+    proxy_pass http://shogun-client:8080/;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This updates the proxy paths for the client and admin applications as they have been updated in [PR 1478](https://github.com/terrestris/shogun-gis-client/pull/1478) and [PR 361](https://github.com/terrestris/shogun-admin/pull/361).

Please review @terrestris/devs.