### PR TITLE
Update README with production notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,3 +314,5 @@ But after the initial installation we strongly recommend to change some defaults
   - Keycloak:
     - Change the password of the `admin` user (see the [documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-setting-password-user_server_administration_guide)).
     - The password needs to be changed in the `.env` file accordingly.
+
+**Note:** Please recheck your installation critically if you need to adjust other parts as well. We don't give any warranty this list is complete!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
     build:
       context: ${SHOGUN_CLIENT_DIR}
       dockerfile: Dockerfile.dev
-    ports:
-      - "3000:3000"
     volumes:
       - ${SHOGUN_CLIENT_DIR}:/app
   shogun-admin:
@@ -48,8 +46,6 @@ services:
     build:
       context: ${SHOGUN_ADMIN_DIR}
       dockerfile: Dockerfile.dev
-    ports:
-      - "9090:9090"
     volumes:
       - ${SHOGUN_ADMIN_DIR}:/app
   shogun-boot:


### PR DESCRIPTION
This updates the README with some notes for the production usage and removes the (invalid) port mapping for client and admin.

Please review @terrestris/devs.