### PR TITLE
Several updates

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -45,8 +45,6 @@ services:
     volumes:
      - ./shogun-keycloak/providers/event-listener-shogun-jar-with-dependencies.jar:/opt/keycloak/providers/event-listener-shogun-jar-with-dependencies.jar
      - ./shogun-keycloak/themes/shogun:/opt/keycloak/themes/shogun
-    depends_on:
-      - shogun-postgis
   shogun-nginx:
     container_name: ${CONTAINER_NAME_PREFIX}-nginx
     image: nginx:1.25.3-alpine
@@ -61,13 +59,6 @@ services:
       - "443:443"
     environment:
       KEYCLOAK_HOST: ${KEYCLOAK_HOST}
-    depends_on:
-      - shogun-keycloak
-      - shogun-boot
-      - shogun-geoserver
-      - shogun-client
-      - shogun-admin
-      - shogun-print
   shogun-client:
     container_name: ${CONTAINER_NAME_PREFIX}-gis-client
   shogun-admin:
@@ -87,9 +78,6 @@ services:
       - ./shogun-boot/keystore/cacerts:/opt/java/openjdk/lib/security/cacerts
       - ./shogun-boot/application.yml:/config/application.yml
       - ./shogun-boot/log4j2.yml:/config/log4j2.yml
-    depends_on:
-      - shogun-postgis
-      - shogun-keycloak
   shogun-gs-interceptor:
     container_name: ${CONTAINER_NAME_PREFIX}-gs-interceptor
     environment:
@@ -101,9 +89,6 @@ services:
     volumes:
       - ./shogun-boot/keystore/cacerts:/etc/pki/ca-trust/extracted/java/cacerts
       - ./shogun-gs-interceptor/application.yml:/config/application.yml
-    depends_on:
-      - shogun-postgis
-      - shogun-keycloak
   shogun-solr:
     container_name: ${CONTAINER_NAME_PREFIX}-solr
     image: solr:9.4.0

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -59,7 +59,7 @@ services:
     image: docker-public.terrestris.de/terrestris/shogun-admin:13.0.1
     restart: unless-stopped
     healthcheck:
-      test: curl --fail http://localhost || exit 1
+      test: wget --no-verbose --tries=1 --spider http://localhost || exit 1
       interval: 10s
       retries: 5
       start_period: 5s
@@ -71,7 +71,7 @@ services:
     image: docker-public.terrestris.de/terrestris/shogun-gis-client:7.3.1
     restart: unless-stopped
     healthcheck:
-      test: curl --fail http://localhost || exit 1
+      test: wget --no-verbose --tries=1 --spider http://localhost || exit 1
       interval: 10s
       retries: 5
       start_period: 5s
@@ -92,7 +92,7 @@ services:
       JAVA_TOOL_OPTIONS: "-Xmx512m -Dspring.config.location=/config/application.yml -Dlog4j2.configurationFile=/config/log4j2.yml"
     restart: unless-stopped
     healthcheck:
-      test: curl --fail "http://localhost:8080" || exit 1
+      test: wget --no-verbose --tries=1 --spider "http://localhost:8080" || exit 1
       interval: 10s
       retries: 5
       start_period: 5s
@@ -104,7 +104,7 @@ services:
     image: docker-public.terrestris.de/shogun/shogun-gs-interceptor:18.0.0
     restart: unless-stopped
     healthcheck:
-      test: curl --fail "http://localhost:8081/shogun-gs-interceptor" || exit 1
+      test: wget --no-verbose --tries=1 --spider "http://localhost:8081/shogun-gs-interceptor/swagger-ui/index.html" || exit 1
       interval: 10s
       retries: 5
       start_period: 5s

--- a/setEnvironment.sh
+++ b/setEnvironment.sh
@@ -43,17 +43,43 @@ MODE=$1
 # GEOSERVER_CSRF_WHITELIST
 GEOSERVER_CSRF_WHITELIST=localhost
 
+POSITIONAL_ARGS=()
+NO_CONFIRM=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -y|--yes)
+      NO_CONFIRM=true
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL_ARGS[@]}"
+
 if [ "$MODE" = "create" ]; then
-  read -rp "This will remove the current .env file. Do you really want to continue (y/n)? "
+  if ! "$NO_CONFIRM"; then
+    read -rp "This will remove the current .env file. Do you really want to continue (y/n)? "
+  fi
 elif [ "$MODE" = "update" ]; then
-  read -rp "This will update the current .env file with your local IP only. Do you want to continue (y/n)? "
+  if ! "$NO_CONFIRM"; then
+    read -rp "This will update the current .env file with your local IP only. Do you want to continue (y/n)? "
+  fi
 else
   echo "Missing argument 'create' or 'update'"
   exit 1
 fi
 
 # Check if prompted to continue
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+if ! "$NO_CONFIRM" && [[ ! $REPLY =~ ^[Yy]$ ]]; then
   exit 1
 fi
 


### PR DESCRIPTION
This applies some updates to the setup:

- Fix the healtchecks (curl isn't available in most images)
- Apply the optional `-y` option for the `setEnvironment.sh` script to skip the confirmation dialog
- Remove the `depends_on` block, it's not supported in combination with `extends` and throws an error since compose version 2.24.6 (see [#11544](https://github.com/docker/compose/issues/11544))

Please review @terrestris/devs.