### PR TITLE
Adds appLogo to config

### DIFF
--- a/shogun-client/config/gis-client-config.js
+++ b/shogun-client/config/gis-client-config.js
@@ -1,4 +1,5 @@
 var clientConfig = {
+  appLogo: '',
   shogunBase: '/',
   keycloak: {
     enabled: true,


### PR DESCRIPTION
This is the path to a potential appLogo.

If the image was uploaded via the shogun-admin-client a path could be like the following:

`/imagefiles/UUID-of-your-image`

For the file to be accessible it needs to be marked as `public`.

External URL's can also be used.

This will only work, if the following MR is merged:

https://github.com/terrestris/shogun-gis-client/pull/1560