### PR TITLE
fix: add defaultSortField

### DIFF
--- a/shogun-admin/modelconfigs/application.json
+++ b/shogun-admin/modelconfigs/application.json
@@ -39,6 +39,7 @@
       "toolTipLink": "Open application"
     }
   },
+  "defaultSortField": "name",
   "endpoint": "/applications",
   "entityType": "application",
   "entityName": "#i18n.entityName",

--- a/shogun-admin/modelconfigs/layer.json
+++ b/shogun-admin/modelconfigs/layer.json
@@ -31,6 +31,7 @@
       "titlePrev": "Layer preview"
     }
   },
+  "defaultSortField": "name",
   "endpoint": "/layers",
   "entityType": "layer",
   "entityName": "#i18n.entityName",


### PR DESCRIPTION
This PR adds the defaultSortField to the configs to give the entity a sort field for a correct sorting over multiple pages in shogun-admin. The defaultSortField is optional.