### PR TITLE
Allow configuration of public applications and layers

### DIFF
--- a/shogun-admin/modelconfigs/application.json
+++ b/shogun-admin/modelconfigs/application.json
@@ -17,7 +17,8 @@
       "titleName": "Name",
       "titleEdit": "Zuletzt editiert am",
       "titleLink": "Link zur Applikation",
-      "toolTipLink": "Öffne Applikation"
+      "toolTipLink": "Öffne Applikation",
+      "isPublic": "Öffentliche Applikation"
     },
     "en": {
       "entityName": "Application",
@@ -36,7 +37,8 @@
       "titleName": "Name",
       "titleEdit": "Last edited on",
       "titleLink": "Link to application",
-      "toolTipLink": "Open application"
+      "toolTipLink": "Open application",
+      "isPublic": "Public application"
     }
   },
   "endpoint": "/applications",
@@ -209,6 +211,7 @@
   },
   "formConfig": {
     "name": "application",
+    "publicKey": "__isPublic__",
     "fields": [
       {
         "dataType": "number",
@@ -247,6 +250,11 @@
         "dataField": "stateOnly",
         "label": "#i18n.labelWork",
         "readOnly": "true"
+      },
+      {
+        "component": "Switch",
+        "dataField": "__isPublic__",
+        "label": "#i18n.isPublic"
       },
       {
         "component": "JSONEditor",

--- a/shogun-admin/modelconfigs/layer.json
+++ b/shogun-admin/modelconfigs/layer.json
@@ -13,7 +13,8 @@
       "titleId": "ID",
       "titleName": "Name",
       "titleType": "Typ",
-      "titlePrev": "Layervorschau"
+      "titlePrev": "Layervorschau",
+      "isPublic": "Öffentlicher Layer"
     },
     "en": {
       "entityName": "Layer",
@@ -28,7 +29,8 @@
       "titleId": "ID",
       "titleName": "Name",
       "titleType": "Type",
-      "titlePrev": "Layer preview"
+      "titlePrev": "Layer preview",
+      "isPublic": "Public layer"
     }
   },
   "endpoint": "/layers",
@@ -49,6 +51,7 @@
   },
   "formConfig": {
     "name": "layer",
+    "publicKey": "__isPublic__",
     "fields": [
       {
         "dataType": "number",
@@ -81,6 +84,11 @@
         "dataField": "name",
         "label": "#i18n.labelName",
         "required": "true"
+      },
+      {
+        "component": "Switch",
+        "dataField": "__isPublic__",
+        "label": "#i18n.isPublic"
       },
       {
         "component": "LayerTypeSelect",

--- a/shogun-client/config/gis-client-config.js
+++ b/shogun-client/config/gis-client-config.js
@@ -5,7 +5,7 @@ var clientConfig = {
     host: 'https://<!--# echo var="keycloakhost" -->/auth',
     realm: 'SHOGun',
     clientId: 'shogun-client',
-    onLoadAction: 'login-required'
+    onLoadAction: 'check-sso'
   },
   print: {
     url: '/print'


### PR DESCRIPTION
This adds a "public" switch to the application and layer form.

It also adapts the `onLoadAction` of the `gis-client-config.js`.
This is needed to allow anonymous acces to the gis-client. Previously keycloak.js always required an authentication.