### PR TITLE
fix: fixes undefined and obsolete version

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ In this case it's necessary to backup and restore all databases manually:
 3. Create a `docker-compose-v13.yml` containing:
 
 ```yml
-version: '3.7'
 services:
   shogun-postgis-old:
     container_name: shogun-postgis-old

--- a/common-services.yml
+++ b/common-services.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   shogun-print:
     container_name: ${CONTAINER_NAME_PREFIX}-print
@@ -69,7 +68,6 @@ services:
       - shogun-geoserver
       - shogun-boot
       - shogun-client
-      - shogun-client-plugins
       - shogun-gis-client-docs
       - shogun-admin
       - shogun-admin-client-docs

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   shogun-print:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   shogun-print:
     extends:


### PR DESCRIPTION
This PR fixes the docker compose command since previously it would report the following
 ```
"version" is obsolete 
service "shogun-nginx" depends on undefined service "shogun-client-plugins": invalid compose project
```