### PR TITLE
feat: adds font size auto-scalability 

### DIFF
--- a/shogun-print/print-apps/default/a4_landscape.jrxml
+++ b/shogun-print/print-apps/default/a4_landscape.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.18.1.final using JasperReports Library version 6.18.1-9d75d1969e774d4f179fb3be8401e98a0e6d1611  -->
+<!-- Created with Jaspersoft Studio version 6.21.2.final using JasperReports Library version 6.21.2-8434a0bd7c3bbc37cbf916f2968d35e4b165821a  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="814" leftMargin="14" rightMargin="14" topMargin="14" bottomMargin="14" uuid="9a3e59f5-6675-48cf-ad74-9c42b5a5b290">
 	<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.HorizontalRowLayout"/>
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
@@ -89,7 +89,7 @@
 				</reportElement>
 			</line>
 			<textField>
-				<reportElement x="679" y="537" width="130" height="30" uuid="21b0a580-9b90-4dac-8a05-6a84deae81b6">
+				<reportElement x="700" y="537" width="109" height="30" uuid="21b0a580-9b90-4dac-8a05-6a84deae81b6">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
@@ -99,8 +99,8 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{copyright}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="5" y="537" width="674" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="537" width="695" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>

--- a/shogun-print/print-apps/default/a4_portrait.jrxml
+++ b/shogun-print/print-apps/default/a4_portrait.jrxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.18.1.final using JasperReports Library version 6.18.1-9d75d1969e774d4f179fb3be8401e98a0e6d1611  -->
+<!-- Created with Jaspersoft Studio version 6.21.2.final using JasperReports Library version 6.21.2-8434a0bd7c3bbc37cbf916f2968d35e4b165821a  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="a4_portrait" pageWidth="595" pageHeight="842" columnWidth="567" leftMargin="14" rightMargin="14" topMargin="14" bottomMargin="14" uuid="71f354e3-dc27-413b-85b6-9150bb8afba3">
 	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="One Empty Record"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
@@ -91,7 +91,7 @@
 				</reportElement>
 			</line>
 			<textField>
-				<reportElement x="457" y="784" width="105" height="30" uuid="21b0a580-9b90-4dac-8a05-6a84deae81b6">
+				<reportElement x="467" y="784" width="95" height="30" uuid="21b0a580-9b90-4dac-8a05-6a84deae81b6">
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
@@ -101,8 +101,8 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{copyright}]]></textFieldExpression>
 			</textField>
-			<textField isBlankWhenNull="true">
-				<reportElement x="5" y="784" width="452" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
+			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
+				<reportElement x="5" y="784" width="460" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
@@ -112,7 +112,7 @@
 				<textElement verticalAlignment="Middle" markup="html">
 					<font size="8.5"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Kommentar: <br/>" + $P{comment}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["Kommentar:" + $P{comment}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="62" y="769" width="500" height="10" uuid="f8217c8e-6c99-418a-8d38-b6b94c67c59f">

--- a/shogun-print/print-apps/default/a4_portrait.jrxml
+++ b/shogun-print/print-apps/default/a4_portrait.jrxml
@@ -112,7 +112,7 @@
 				<textElement verticalAlignment="Middle" markup="html">
 					<font size="8.5"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Kommentar:" + $P{comment}]]></textFieldExpression>
+				<textFieldExpression><![CDATA["Kommentar: <br/>" + $P{comment}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement x="62" y="769" width="500" height="10" uuid="f8217c8e-6c99-418a-8d38-b6b94c67c59f">


### PR DESCRIPTION
Inorder to accomodate the 200 character upper-limit in the comment report element, an auto-scale property for text-fontsize was added in the report.