### PR TITLE
feat: revise layout of the printform

### DIFF
--- a/shogun-print/print-apps/default/a4_landscape.jrxml
+++ b/shogun-print/print-apps/default/a4_landscape.jrxml
@@ -88,19 +88,8 @@
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 			</line>
-			<textField>
-				<reportElement x="700" y="537" width="109" height="30" uuid="21b0a580-9b90-4dac-8a05-6a84deae81b6">
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<textElement textAlignment="Right" verticalAlignment="Middle" markup="html">
-					<font size="9"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{copyright}]]></textFieldExpression>
-			</textField>
 			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
-				<reportElement x="5" y="537" width="695" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
+				<reportElement x="5" y="537" width="804" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
@@ -108,7 +97,7 @@
 					<printWhenExpression><![CDATA[$P{comment} !=null && !$P{comment}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement verticalAlignment="Middle" markup="html">
-					<font size="9"/>
+					<font size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Kommentar: <br/>" + $P{comment}]]></textFieldExpression>
 			</textField>

--- a/shogun-print/print-apps/default/a4_portrait.jrxml
+++ b/shogun-print/print-apps/default/a4_portrait.jrxml
@@ -90,19 +90,8 @@
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 				</reportElement>
 			</line>
-			<textField>
-				<reportElement x="467" y="784" width="95" height="30" uuid="21b0a580-9b90-4dac-8a05-6a84deae81b6">
-					<property name="com.jaspersoft.studio.unit.x" value="px"/>
-					<property name="com.jaspersoft.studio.unit.y" value="px"/>
-					<property name="com.jaspersoft.studio.unit.width" value="px"/>
-				</reportElement>
-				<textElement textAlignment="Right" verticalAlignment="Middle" markup="html">
-					<font size="8.5"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{copyright}]]></textFieldExpression>
-			</textField>
 			<textField textAdjust="ScaleFont" isBlankWhenNull="true">
-				<reportElement x="5" y="784" width="460" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
+				<reportElement x="5" y="784" width="557" height="30" uuid="ab2fdb11-0704-4e55-90a9-974311bd60cc">
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
@@ -110,7 +99,7 @@
 					<printWhenExpression><![CDATA[$P{comment} !=null && !$P{comment}.isEmpty()]]></printWhenExpression>
 				</reportElement>
 				<textElement verticalAlignment="Middle" markup="html">
-					<font size="8.5"/>
+					<font size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Kommentar: <br/>" + $P{comment}]]></textFieldExpression>
 			</textField>


### PR DESCRIPTION
Revises the layout of the print form by removing the non-functional copyright element which was replaced with  the attributes element and making the text area for comments larger.

@terrestris/devs please review 

Before:
![image](https://github.com/terrestris/shogun-docker/assets/130636985/d3c65462-5674-4171-8600-ae70fe83eb04)

After:
![image](https://github.com/terrestris/shogun-docker/assets/130636985/54b850a2-608d-4d67-91cb-9a7fda0d944e)

