### PR TITLE
fix: use service name instead of container name in nginx

### DIFF
--- a/shogun-nginx/prod/default.conf
+++ b/shogun-nginx/prod/default.conf
@@ -97,7 +97,7 @@ server {
   }
 
   location /client/ {
-    proxy_pass http://shogun-gis-client/;
+    proxy_pass http://shogun-client/;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
See https://github.com/terrestris/shogun-docker/blob/27e64121314809f5a8135a458c7967e3481fd6ab/docker-compose-prod.yml#L60

This will work even if the container name prefix is different