### PR TITLE
feat: add geoserver proxy url env variable

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -16,6 +16,7 @@ services:
       service: shogun-geoserver
     image: docker.osgeo.org/geoserver:2.25.3
     environment:
+      # in some environments the X-Forward-Proto is not picked up correctly, with this variable it can be set manually
       PROXY_BASE_URL: ${GEOSERVER_PROXY_BASE_URL}
     restart: unless-stopped
     healthcheck:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,6 +15,8 @@ services:
       file: ./common-services.yml
       service: shogun-geoserver
     image: docker.osgeo.org/geoserver:2.25.3
+    environment:
+      PROXY_BASE_URL: ${GEOSERVER_PROXY_BASE_URL}
     restart: unless-stopped
     healthcheck:
       test: curl --fail "http://localhost:8080/geoserver/web" || exit 1

--- a/setEnvironment.sh
+++ b/setEnvironment.sh
@@ -111,6 +111,7 @@ if [ "$MODE" = "create" ]; then
   echo "UNAME=${USER_NAME}" >> $SCRIPT_DIR/$ENV_FILE
 
   echo "GEOSERVER_CSRF_WHITELIST=${GEOSERVER_CSRF_WHITELIST}" >> $SCRIPT_DIR/$ENV_FILE
+  echo "GEOSERVER_PROXY_BASE_URL=" >> $SCRIPT_DIR/$ENV_FILE
 
   echo "Successfully wrote $SCRIPT_DIR/$ENV_FILE"
 else


### PR DESCRIPTION
Add an environment variable to set the geoserver proxy url. The `${X-Forward-Proto}` value from the geoserver default configuration is not picked up correctly in the prod setup somehow.