### PR TITLE
docs: add step to readme to allow writing access for solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ your-shogun-workspace-directory/
 - Set all required environment variables (and create a local SSL certificate) by executing `./setEnvironment.sh create` (and adjusting the values if needed).
 - If you are using a different directory layout, make sure to adjust the paths in the `.env` file
 - Import the initial Keycloak data, see section [Keycloak Import](#import).
+- execute `chmod -R a+w shogun-solr/solr_data` to allow the solr service to write to the directory.
 
 ### Startup
 

--- a/common-services.yml
+++ b/common-services.yml
@@ -114,7 +114,7 @@ services:
     container_name: ${CONTAINER_NAME_PREFIX}-solr
     image: solr:9.7.0
     volumes:
-      - ./shogun-solr/solr_data:/var/solr:RW
+      - ./shogun-solr/solr_data:/var/solr
       - ./shogun-solr/jts.jar:/opt/solr/server/solr-webapp/webapp/WEB-INF/lib/jts.jar
   shogun-gis-client-docs:
     container_name: ${CONTAINER_NAME_PREFIX}-gis-client-docs


### PR DESCRIPTION
This removes :RW from the shogun-solr volume as it is the default and adds a step to the README file to allow solr writing access.