### PR TITLE
Enable all permission grids for applications and layers

### DIFF
--- a/shogun-admin/config/admin-client-config.js
+++ b/shogun-admin/config/admin-client-config.js
@@ -28,7 +28,8 @@ var shogunApplicationConfig = {
     'Application',
     'Layer',
     'User',
-    'Group'
+    'Group',
+    'Role'
   ],
   dashboard: {
     news: {

--- a/shogun-admin/modelconfigs/application.json
+++ b/shogun-admin/modelconfigs/application.json
@@ -13,6 +13,8 @@
       "labelLayerConfig": "Layer-Konfiguration",
       "labelToolConfig": "Werkzeug Konfiguration",
       "labelUserPermissions": "Nutzerberechtigungen",
+      "labelGroupPermissions": "Gruppenberechtigungen",
+      "labelRolePermissions": "Rollenberechtigungen",
       "titleId": "ID",
       "titleName": "Name",
       "titleEdit": "Zuletzt editiert am",
@@ -33,6 +35,8 @@
       "labelLayerConfig": "Layer configuration",
       "labelToolConfig": "Configure Tools",
       "labelUserPermissions": "User permissions",
+      "labelGroupPermissions": "Group permissions",
+      "labelRolePermissions": "Role permissions",
       "titleId": "ID",
       "titleName": "Name",
       "titleEdit": "Last edited on",
@@ -288,6 +292,16 @@
       {
         "component": "UserPermissionGrid",
         "label": "#i18n.labelUserPermissions",
+        "fieldProps": {}
+      },
+      {
+        "component": "GroupPermissionGrid",
+        "label": "#i18n.labelGroupPermissions",
+        "fieldProps": {}
+      },
+      {
+        "component": "RolePermissionGrid",
+        "label": "#i18n.labelRolePermissions",
         "fieldProps": {}
       }
     ]

--- a/shogun-admin/modelconfigs/layer.json
+++ b/shogun-admin/modelconfigs/layer.json
@@ -10,6 +10,9 @@
       "labelType": "Typ",
       "labelConfig": "Konfiguration",
       "labelSource": "Datenquelle",
+      "labelUserPermissions": "Nutzerberechtigungen",
+      "labelGroupPermissions": "Gruppenberechtigungen",
+      "labelRolePermissions": "Rollenberechtigungen",
       "titleId": "ID",
       "titleName": "Name",
       "titleType": "Typ",
@@ -26,6 +29,9 @@
       "labelType": "Type",
       "labelConfig": "Configuration",
       "labelSource": "Datasource",
+      "labelUserPermissions": "User permissions",
+      "labelGroupPermissions": "Group permissions",
+      "labelRolePermissions": "Role permissions",
       "titleId": "ID",
       "titleName": "Name",
       "titleType": "Type",
@@ -117,6 +123,21 @@
         "component": "JSONEditor",
         "dataField": "sourceConfig",
         "label": "#i18n.labelSource",
+        "fieldProps": {}
+      },
+      {
+        "component": "UserPermissionGrid",
+        "label": "#i18n.labelUserPermissions",
+        "fieldProps": {}
+      },
+      {
+        "component": "GroupPermissionGrid",
+        "label": "#i18n.labelGroupPermissions",
+        "fieldProps": {}
+      },
+      {
+        "component": "RolePermissionGrid",
+        "label": "#i18n.labelRolePermissions",
         "fieldProps": {}
       }
     ]

--- a/shogun-admin/modelconfigs/role.json
+++ b/shogun-admin/modelconfigs/role.json
@@ -1,8 +1,8 @@
 {
   "i18n": {
     "de": {
-      "entityName": "Gruppe",
-      "navigationTitle": "Gruppen",
+      "entityName": "Rolle",
+      "navigationTitle": "Rollen",
       "labelId": "ID",
       "labelEstabl": "Erstellt am",
       "labelEdit": "Zuletzt editiert am",
@@ -10,14 +10,14 @@
       "labelKeyProvDetail": "Keycloak Details",
       "titleId": "ID",
       "titleKeyId": "Keycloak ID",
-      "userDoesNotExistTitle": "Die Gruppe existiert nicht in Keycloak",
-      "titleGroupname": "Gruppenname",
-      "titleLink": "Link zur Gruppe",
-      "titleGroup": "Öffne Gruppe in Keycloak"
+      "roleDoesNotExistTitle": "Die Rolle existiert nicht in Keycloak",
+      "titleRolename": "Rollenname",
+      "titleLink": "Link zur Rolle",
+      "titleOpen": "Öffne Rolle in Keycloak"
     },
     "en": {
-      "entityName": "Group",
-      "navigationTitle": "Groups",
+      "entityName": "Role",
+      "navigationTitle": "Roles",
       "labelId": "ID",
       "labelEstabl": "Created at",
       "labelEdit": "Last edited on",
@@ -25,19 +25,19 @@
       "labelKeyProvDetail": "Keycloak details",
       "titleId": "ID",
       "titleKeyId": "Keycloak ID",
-      "userDoesNotExistTitle": "Group does not exist in Keycloak",
-      "titleGroupname": "Group name",
-      "titleLink": "Link to group",
-      "titleGroup": "Open group in Keycloak"
+      "roleDoesNotExistTitle": "Role does not exist in Keycloak",
+      "titleRolename": "Role name",
+      "titleLink": "Link to role",
+      "titleOpen": "Open role in Keycloak"
     }
   },
-  "endpoint": "/groups",
-  "entityType": "group",
+  "endpoint": "/roles",
+  "entityType": "role",
   "entityName": "#i18n.entityName",
   "navigationTitle": "#i18n.navigationTitle",
   "subTitle": "",
   "formConfig": {
-    "name": "group",
+    "name": "role",
     "fields": [
       {
         "dataType": "number",
@@ -88,7 +88,7 @@
         }
       },
       {
-        "title": "#i18n.titleGroupname",
+        "title": "#i18n.titleRolename",
         "dataIndex": ["providerDetails", "name"],
         "key": "name",
         "sortConfig": {
@@ -104,7 +104,7 @@
         "key": "authProviderId",
         "cellRenderComponentName": "VerifyProviderDetailsCell",
         "cellRenderComponentProps": {
-          "title": "#i18n.groupDoesNotExistTitle"
+          "title": "#i18n.roleDoesNotExistTitle"
         },
         "sortConfig": {
           "isSortable": true
@@ -119,8 +119,8 @@
         "key": "link",
         "cellRenderComponentName": "LinkCell",
         "cellRenderComponentProps": {
-          "title": "#i18n.titleGroup",
-          "template": "/auth/admin/master/console/#/SHOGun/groups/{}"
+          "title": "#i18n.titleOpen",
+          "template": "/auth/admin/master/console/#/SHOGun/clients/6b26da98-7e18-4c7f-9379-412c01e648e5/roles/{}/details"
         }
       }
     ]


### PR DESCRIPTION
This enables all permissions grids (user, group and role) for the `Application` and `Layer` entities.

In real world scenarios it's probably not needed to enable them all, but for demo purposes it might be a good starter.

Please review @terrestris/devs.