### PR TITLE
Remove the GeoServer session cookie if a bearer token is present

### DIFF
--- a/shogun-nginx/dev/default.conf
+++ b/shogun-nginx/dev/default.conf
@@ -1,3 +1,8 @@
+map $http_authorization $unset_header {
+  default       $http_cookie;
+  ~*Bearer\ .+  "";
+}
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server;
@@ -57,6 +62,9 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Port $server_port;
+
+    # Remove the session cookie if a bearer token is present.
+    proxy_set_header Cookie $unset_header;
 
     proxy_read_timeout 600;
 

--- a/shogun-nginx/prod/default.conf
+++ b/shogun-nginx/prod/default.conf
@@ -1,3 +1,8 @@
+map $http_authorization $unset_header {
+  default       $http_cookie;
+  ~*Bearer\ .+  "";
+}
+
 upstream shogun-boot {
   server shogun-boot:8080;
 }
@@ -61,6 +66,9 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Port $server_port;
+
+    # Remove the session cookie if a bearer token is present.
+    proxy_set_header Cookie $unset_header;
 
     proxy_read_timeout 600;
 


### PR DESCRIPTION
This removes any `Cookie` header from the request to the GeoServer if a bearer token is present as well. It should fix a common issue if a user has logged in to the GeoServer UI in parallel to using it's services in the GIS client since the cookie has priority over the token.

Please review @terrestris/devs.