### PR TITLE
Deactivate hibernate statistics

### DIFF
--- a/shogun-boot/application.yml
+++ b/shogun-boot/application.yml
@@ -23,7 +23,7 @@ spring:
     banner-mode: off
   jpa:
     # Show SQL statements
-    show-sql: true
+    show-sql: false
     open-in-view: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -49,7 +49,7 @@ spring:
           db_structure_naming_strategy: single
         format_sql: true
         # Generate statistics to check if L2/query cache is actually being used
-        generate_statistics: true
+        generate_statistics: false
         cache:
           # Enable L2 cache
           use_second_level_cache: true


### PR DESCRIPTION
This suggests to deactivate the hibernate statistics by default to keep the logs more clean.

Please review @terrestris/devs.