### PR TITLE
Update config to include `KEYCLOAK_ADMIN_CLIENT_SECRET`

### DIFF
--- a/common-services.yml
+++ b/common-services.yml
@@ -91,8 +91,7 @@ services:
       DB_USER: ${POSTGRES_USER}
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       KEYCLOAK_HOST: ${KEYCLOAK_HOST}
-      KEYCLOAK_USER: ${KEYCLOAK_USER}
-      KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}
+      KEYCLOAK_ADMIN_CLIENT_SECRET: ${KEYCLOAK_ADMIN_CLIENT_SECRET}
     depends_on:
       shogun-postgis:
         condition: service_healthy

--- a/setEnvironment.sh
+++ b/setEnvironment.sh
@@ -30,6 +30,8 @@ KEYCLOAK_HOST=$(ip route get 1 | awk '{gsub("^.*src ",""); print $1; exit}')
 KEYCLOAK_USER=admin
 # The Keycloak admin password
 KEYCLOAK_PASSWORD=shogun
+# The secret of the admin-cli client
+KEYCLOAK_ADMIN_CLIENT_SECRET=supersecret
 
 # The ID of the host user the GS image should run as
 USER_ID=$(id -u)
@@ -107,6 +109,7 @@ if [ "$MODE" = "create" ]; then
   echo "KEYCLOAK_HOST=${KEYCLOAK_HOST}" >> $SCRIPT_DIR/$ENV_FILE
   echo "KEYCLOAK_USER=${KEYCLOAK_USER}" >> $SCRIPT_DIR/$ENV_FILE
   echo "KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD}" >> $SCRIPT_DIR/$ENV_FILE
+  echo "KEYCLOAK_ADMIN_CLIENT_SECRET=${KEYCLOAK_ADMIN_CLIENT_SECRET}" >> $SCRIPT_DIR/$ENV_FILE
 
   echo "UID=${USER_ID}" >> $SCRIPT_DIR/$ENV_FILE
   echo "GID=${GROUP_ID}" >> $SCRIPT_DIR/$ENV_FILE

--- a/shogun-boot/application.yml
+++ b/shogun-boot/application.yml
@@ -112,14 +112,15 @@ spring:
 keycloak:
   enabled: true
   server-url: https://${KEYCLOAK_HOST:shogun-keycloak}/auth
-  username: ${KEYCLOAK_USER}
-  password: ${KEYCLOAK_PASSWORD}
-  master-realm: master
+  master-realm: SHOGun
   admin-client-id: admin-cli
+  admin-client-secret: ${KEYCLOAK_ADMIN_CLIENT_SECRET}
   realm: SHOGun
   client-id: shogun-boot
   principal-attribute: preferred_username
-  disableHostnameVerification: true
+  disable-hostname-verification: true
+  extract-roles-from-resource: true
+  extract-roles-from-realm: false
 
 controller:
   applications:


### PR DESCRIPTION
See [!963](https://github.com/terrestris/shogun/pull/963) for details.

TODO: If the PR gets merged we might think about updating the keyloak dump to actually include the required settings for the `admin-cli` client.