### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ your-shogun-workspace-directory/
   - shogun-gis-client-example-plugin: `npm i`
   - shogun-admin: `npm i`
   - shogun: `mvn clean install -DskipTests -Djib.skip=true`
-  - shogun-docker: `docker compose pull`
 - Set all required environment variables (and create a local SSL certificate) by executing `./setEnvironment.sh create` (and adjusting the values if needed).
 - If you are using a different directory layout, make sure to adjust the paths in the `.env` file
 - Import the initial Keycloak data, see section [Keycloak Import](#import).


### PR DESCRIPTION
This suggests to remove an unneeded command from the README since it might fail at the very first start if the `startEnvironment.sh` hasn't been executed and the images will be pulled in the following `docker compose up` anyway.

Please note @terrestris/devs.