### PR TITLE
Add job to trigger external repository pipeline

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,0 +1,18 @@
+name: Trigger GitLab pipeline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-gitlab-pipeline:
+    name: Trigger GitLab pipeline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitLab pipeline 🚀
+        run: |
+          curl -X POST \
+            -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} \
+            -F ref=${{ secrets.GITLAB_PROJECT_REF }} \
+            https://${{ secrets.GITLAB_URL }}/api/v4/projects/${{ secrets.GITLAB_PROJECT_ID }}/trigger/pipeline


### PR DESCRIPTION
This adds a job to call an external [GitLab trigger pipeline API](https://docs.gitlab.com/ci/triggers/).

Please review @terrestris/devs.